### PR TITLE
Changed the title of the citrix communtiy scripts view

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Citrix Developer tools for Visual Studio Code is an extension that helps develop
 
 ## Features
 
+### Implemented in this release (1.4.2)
+
+- Change the title of the "Citrix Community Scripts" to "Community Scripts" to encourage that this is for all types of community scripts, not just Citrix. If you build a script package, no matter what platform it targets, it will be surfaced here.
+
 ### Implemented in this release (1.4.1)
 
 - Settings to specify a RSS feed to list Citrix Script Packages

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "citrixdeveloper-vscode",
     "displayName": "Citrix Developer tools for Visual Studio Code",
     "description": "Tooling, samples and sdk documentation to help you get with building Citrix enabled applications.",
-    "version": "1.4.1",
+    "version": "1.4.2",
     "publisher": "CitrixDeveloper",
     "contributors": [
         "John McBride"
@@ -80,7 +80,7 @@
                 },
                 {
                     "id": "citrix.view.citrix-scripts",
-                    "name": "Citrix Community Scripts"
+                    "name": "Community Scripts"
                 }
             ]
         },


### PR DESCRIPTION
Change the title of the view to encourage other community member to submit script packages. This highlights all community scripts, not just citrix.